### PR TITLE
Add fixed links tabs

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -91,6 +91,31 @@
       margin: 40px 0 20px 0;
     }
 
+    .fixed-tabs {
+      position: fixed;
+      right: 1rem;
+      bottom: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      z-index: 999;
+    }
+
+    .fixed-tabs a {
+      background-color: var(--bg-color);
+      border: 1px solid var(--text-color);
+      border-radius: 6px;
+      padding: 0.4rem 0.8rem;
+      font-size: 0.85rem;
+      color: var(--text-color);
+      text-decoration: none;
+      text-align: center;
+    }
+
+    .fixed-tabs a:hover {
+      background-color: var(--accent-color);
+    }
+
     @media (max-width: 600px) {
       header {
         flex-direction: column;
@@ -191,6 +216,12 @@
 
   <div class="footer">
     &copy; 2025 ChiuGa Studio. All rights reserved.
+  </div>
+
+  <div class="fixed-tabs">
+    <a href="../supports/support.html">支援</a>
+    <a href="../terms/terms.html">使用者條款</a>
+    <a href="PrivacyPolicies.html">隱私政策</a>
   </div>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -95,6 +95,31 @@
       margin-top: 3rem;
     }
 
+    .fixed-tabs {
+      position: fixed;
+      right: 1rem;
+      bottom: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      z-index: 999;
+    }
+
+    .fixed-tabs a {
+      background-color: var(--bg-color);
+      border: 1px solid var(--text-color);
+      border-radius: 6px;
+      padding: 0.4rem 0.8rem;
+      font-size: 0.85rem;
+      color: var(--text-color);
+      text-decoration: none;
+      text-align: center;
+    }
+
+    .fixed-tabs a:hover {
+      background-color: var(--accent-color);
+    }
+
     @media (max-width: 600px) {
       header {
         flex-direction: column;
@@ -149,5 +174,11 @@
   <footer>
     © 2024 ChiuGa Studio. All rights reserved.
   </footer>
+
+  <div class="fixed-tabs">
+    <a href="supports/support.html">支援</a>
+    <a href="terms/terms.html">使用者條款</a>
+    <a href="PrivacyPolicies/PrivacyPolicies.html">隱私政策</a>
+  </div>
 </body>
 </html>

--- a/supports/support.html
+++ b/supports/support.html
@@ -108,6 +108,31 @@
     margin: 40px 0 20px 0;
   }
 
+  .fixed-tabs {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 999;
+  }
+
+  .fixed-tabs a {
+    background-color: var(--bg-color);
+    border: 1px solid var(--text-color);
+    border-radius: 6px;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
+    color: var(--text-color);
+    text-decoration: none;
+    text-align: center;
+  }
+
+  .fixed-tabs a:hover {
+    background-color: var(--accent-color);
+  }
+
   @media (max-width: 600px) {
     header {
       flex-direction: column;
@@ -186,6 +211,12 @@
 
   <div class="footer">
     &copy; 2025 ChiuGa Studio. All rights reserved.
+  </div>
+
+  <div class="fixed-tabs">
+    <a href="support.html">支援</a>
+    <a href="../terms/terms.html">使用者條款</a>
+    <a href="../PrivacyPolicies/PrivacyPolicies.html">隱私政策</a>
   </div>
 
  <!-- 請將此段直接放入原本位置，原結構保留，只替換 <script> 區塊 -->

--- a/terms/terms.html
+++ b/terms/terms.html
@@ -67,6 +67,31 @@
       color: var(--text-color);
     }
 
+    .fixed-tabs {
+      position: fixed;
+      right: 1rem;
+      bottom: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      z-index: 999;
+    }
+
+    .fixed-tabs a {
+      background-color: var(--bg-color);
+      border: 1px solid var(--text-color);
+      border-radius: 6px;
+      padding: 0.4rem 0.8rem;
+      font-size: 0.85rem;
+      color: var(--text-color);
+      text-decoration: none;
+      text-align: center;
+    }
+
+    .fixed-tabs a:hover {
+      background-color: var(--accent-color);
+    }
+
     @media (max-width: 600px) {
       header {
         flex-direction: column;
@@ -160,5 +185,11 @@
   <footer>
     © 2025 ChiuGa Studio. All rights reserved.
   </footer>
+
+  <div class="fixed-tabs">
+    <a href="../supports/support.html">支援</a>
+    <a href="terms.html">使用者條款</a>
+    <a href="../PrivacyPolicies/PrivacyPolicies.html">隱私政策</a>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- place support/legal links in a new `.fixed-tabs` element
- pin the tabs to the bottom-right on every page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68765f09e7e0832bb483f67a99e26176