### PR TITLE
Improve mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,10 +65,10 @@
 
     <!-- Mobile Menu -->
     <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4">
-        <nav class="flex flex-col space-y-2">
-            <a href="#" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
-            <a href="#features" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
-            <a href="#showcase" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
+        <nav class="flex flex-col space-y-4">
+            <a href="#" class="text-lg py-2 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
+            <a href="#features" class="text-lg py-2 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
+            <a href="#showcase" class="text-lg py-2 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
         </nav>
     </div>
 
@@ -119,7 +119,7 @@
     </section>
 
      <!-- Features Section -->
-    <section id="features" class="py-12 px-6 md:px-12 bg-white text-[#2D2926]">
+    <section id="features" class="py-12 px-6 md:px-12 bg-white text-[#2D2926] scroll-mt-24">
          <h2 class="text-2xl font-bold mb-10 text-center">主要功能</h2>
         <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
             <div class="bg-gray-50 p-6 rounded-lg shadow text-center">
@@ -181,7 +181,7 @@
     </section>
 
 <!-- Showcase Section -->
-    <section id="showcase" class="py-12 px-6 md:px-12 bg-gray-50">
+    <section id="showcase" class="py-12 px-6 md:px-12 bg-gray-50 scroll-mt-24">
         <h2 class="text-2xl font-bold mb-10 text-center text-[#2D2926]">免費與Premium</h2>
         <div class="max-w-3xl mx-auto overflow-x-auto">
             <table class="w-full table-auto text-center bg-white rounded-lg shadow-md">
@@ -317,6 +317,11 @@
         if (menuBtn && mobileMenu) {
             menuBtn.addEventListener('click', () => {
                 mobileMenu.classList.toggle('hidden');
+            });
+            mobileMenu.querySelectorAll('a').forEach(link => {
+                link.addEventListener('click', () => {
+                    mobileMenu.classList.add('hidden');
+                });
             });
         }
     </script>


### PR DESCRIPTION
## Summary
- enlarge mobile menu items for easier tapping
- ensure mobile menu hides after selection
- offset anchor sections so sticky header doesn't cover them

## Testing
- `tidy -q -e index.html` *(fails: command not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68775bcbbe00832b96f07ae5737f17ea