### PR TITLE
Fix mobile menu size and anchor offset

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -53,8 +53,8 @@
 
     <!-- Mobile Menu -->
     <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4">
-        <nav class="flex flex-col space-y-2">
-            <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
+        <nav class="flex flex-col space-y-4">
+            <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -66,9 +66,9 @@
     <!-- Mobile Menu -->
     <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4">
         <nav class="flex flex-col space-y-4">
-            <a href="#" class="text-lg py-2 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
-            <a href="#features" class="text-lg py-2 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
-            <a href="#showcase" class="text-lg py-2 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
+            <a href="#" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
+            <a href="#features" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
+            <a href="#showcase" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
         </nav>
     </div>
 
@@ -119,7 +119,7 @@
     </section>
 
      <!-- Features Section -->
-    <section id="features" class="py-12 px-6 md:px-12 bg-white text-[#2D2926] scroll-mt-24">
+    <section id="features" class="py-12 px-6 md:px-12 bg-white text-[#2D2926] scroll-mt-20">
          <h2 class="text-2xl font-bold mb-10 text-center">主要功能</h2>
         <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
             <div class="bg-gray-50 p-6 rounded-lg shadow text-center">
@@ -181,7 +181,7 @@
     </section>
 
 <!-- Showcase Section -->
-    <section id="showcase" class="py-12 px-6 md:px-12 bg-gray-50 scroll-mt-24">
+    <section id="showcase" class="py-12 px-6 md:px-12 bg-gray-50 scroll-mt-20">
         <h2 class="text-2xl font-bold mb-10 text-center text-[#2D2926]">免費與Premium</h2>
         <div class="max-w-3xl mx-auto overflow-x-auto">
             <table class="w-full table-auto text-center bg-white rounded-lg shadow-md">

--- a/supports/support.html
+++ b/supports/support.html
@@ -61,8 +61,8 @@
 
     <!-- Mobile Menu -->
     <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4">
-        <nav class="flex flex-col space-y-2">
-            <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
+        <nav class="flex flex-col space-y-4">
+            <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
     </div>
 

--- a/terms/terms.html
+++ b/terms/terms.html
@@ -53,8 +53,8 @@
 
     <!-- Mobile Menu -->
     <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4">
-        <nav class="flex flex-col space-y-2">
-            <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
+        <nav class="flex flex-col space-y-4">
+            <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
     </div>
 


### PR DESCRIPTION
## Summary
- adjust scroll offset so anchor links land more precisely
- enlarge mobile menu items for easier tapping across all pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877a7135c7c832bb95b6e412227b9b6