### PR TITLE
Increase hero title size on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <section class="hero-gradient py-16 md:py-24 px-6 md:px-12 text-[#2D2926] flex flex-col md:flex-row items-center justify-between gap-12 rounded-b-xl">
         <!-- Hero Text Content -->
         <div class="flex-1 text-leading md:text-leading">
-            <h1 class="text-3xl md:text-4xl lg:text-8xl font-extrabold leading-tight mb-6">
+            <h1 class="text-4xl md:text-5xl lg:text-8xl font-extrabold leading-tight mb-6">
                 記食開始
             </h1>
             <h1 class="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-6">


### PR DESCRIPTION
## Summary
- revert header link text to original size
- enlarge the hero section's main heading so it appears larger on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a7ce4f28832bb30b96c296a58017