### PR TITLE
Add language switcher via Google Translate

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -45,6 +45,7 @@
         <nav class="hidden md:flex space-x-8">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
+        <div id="google_translate_element" class="hidden md:block"></div>
         <!-- Mobile menu button (hidden on desktop) -->
         <button id="mobile-menu-button" class="md:hidden text-primary-dark hover:text-accent focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -56,6 +57,7 @@
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
+        <div id="google_translate_element_mobile" class="mt-4"></div>
     </div>
 
     <!-- Main Content Container - Styled like a card -->
@@ -152,6 +154,21 @@
             });
         }
     </script>
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element_mobile');
+        }
+    </script>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
             <a href="#features" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
             <a href="#showcase" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
         </nav>
+        <div id="google_translate_element" class="hidden md:block"></div>
         <!-- Mobile menu button (hidden on desktop) -->
        <button id="mobile-menu-button" class="md:hidden text-[#2D2926] hover:text-[#B8B0A6] focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -70,6 +71,7 @@
             <a href="#features" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
             <a href="#showcase" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
         </nav>
+        <div id="google_translate_element_mobile" class="mt-4"></div>
     </div>
 
     <!-- Hero Section -->
@@ -325,5 +327,20 @@
             });
         }
     </script>
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element_mobile');
+        }
+    </script>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/supports/support.html
+++ b/supports/support.html
@@ -51,8 +51,8 @@
         <!-- Navigation - Only "首頁" link -->
         <nav class="hidden md:flex space-x-8 items-center">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
-            <!-- Language Toggle Button removed -->
         </nav>
+        <div id="google_translate_element" class="hidden md:block"></div>
         <!-- Mobile menu button (hidden on desktop) -->
                <button id="mobile-menu-button" class="md:hidden text-primary-dark hover:text-accent focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -64,6 +64,7 @@
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
+        <div id="google_translate_element_mobile" class="mt-4"></div>
     </div>
 
     <!-- Main Content Container - Styled like a card -->
@@ -127,6 +128,21 @@
             });
         }
     </script>
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element_mobile');
+        }
+    </script>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
     <!-- Language Toggle Script removed -->
 </body>
 </html>

--- a/terms/terms.html
+++ b/terms/terms.html
@@ -45,6 +45,7 @@
         <nav class="hidden md:flex space-x-8 items-center">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
+        <div id="google_translate_element" class="hidden md:block"></div>
         <!-- Mobile menu button (hidden on desktop) -->
           <button id="mobile-menu-button" class="md:hidden text-primary-dark hover:text-accent focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -56,6 +57,7 @@
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
+        <div id="google_translate_element_mobile" class="mt-4"></div>
     </div>
 
     <!-- Main Content Container - Styled like a card -->
@@ -219,5 +221,20 @@
             });
         }
     </script>
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+            new google.translate.TranslateElement({
+                pageLanguage: 'zh-TW',
+                includedLanguages: 'zh-TW,en,ja,ko',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element_mobile');
+        }
+    </script>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed Google Translate widget on all pages
- show the translate button beside the navigation on desktop and in the mobile menu
- language choice persists via Google cookie across pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880ebadbab8832bafad2a94ce97b256