### PR TITLE
Add language switcher controls to all pages

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -45,7 +45,13 @@
         <nav class="hidden md:flex space-x-8">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <div id="google_translate_element" class="hidden md:block"></div>
+        <select id="lang-switcher" class="hidden md:block border border-gray-300 rounded-md text-sm px-2 py-1 ml-4">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element" class="hidden"></div>
         <!-- Mobile menu button (hidden on desktop) -->
         <button id="mobile-menu-button" class="md:hidden text-primary-dark hover:text-accent focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -57,7 +63,13 @@
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <div id="google_translate_element_mobile" class="mt-4"></div>
+        <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element_mobile" class="hidden"></div>
     </div>
 
     <!-- Main Content Container - Styled like a card -->
@@ -167,6 +179,33 @@
                 layout: google.translate.TranslateElement.InlineLayout.SIMPLE
             }, 'google_translate_element_mobile');
         }
+
+        function getCurrentLang() {
+            const match = document.cookie.match(/googtrans=\/auto\/([^;]+)/);
+            return match ? match[1] : 'zh-TW';
+        }
+
+        function setLang(lang) {
+            const value = '/auto/' + lang;
+            document.cookie = 'googtrans=' + value + '; path=/';
+            document.cookie = 'googtrans=' + value + '; path=/; domain=' + window.location.hostname;
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const desktop = document.getElementById('lang-switcher');
+            const mobile = document.getElementById('lang-switcher-mobile');
+            const current = getCurrentLang();
+            if (desktop) desktop.value = current;
+            if (mobile) mobile.value = current;
+            [desktop, mobile].forEach(sel => {
+                if (sel) {
+                    sel.addEventListener('change', () => {
+                        setLang(sel.value);
+                        location.reload();
+                    });
+                }
+            });
+        });
     </script>
     <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 

--- a/index.html
+++ b/index.html
@@ -57,7 +57,13 @@
             <a href="#features" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
             <a href="#showcase" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
         </nav>
-        <div id="google_translate_element" class="hidden md:block"></div>
+        <select id="lang-switcher" class="hidden md:block border border-gray-300 rounded-md text-sm px-2 py-1 ml-4">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element" class="hidden"></div>
         <!-- Mobile menu button (hidden on desktop) -->
        <button id="mobile-menu-button" class="md:hidden text-[#2D2926] hover:text-[#B8B0A6] focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -71,7 +77,13 @@
             <a href="#features" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
             <a href="#showcase" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
         </nav>
-        <div id="google_translate_element_mobile" class="mt-4"></div>
+        <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element_mobile" class="hidden"></div>
     </div>
 
     <!-- Hero Section -->
@@ -340,6 +352,33 @@
                 layout: google.translate.TranslateElement.InlineLayout.SIMPLE
             }, 'google_translate_element_mobile');
         }
+
+        function getCurrentLang() {
+            const match = document.cookie.match(/googtrans=\/auto\/([^;]+)/);
+            return match ? match[1] : 'zh-TW';
+        }
+
+        function setLang(lang) {
+            const value = '/auto/' + lang;
+            document.cookie = 'googtrans=' + value + '; path=/';
+            document.cookie = 'googtrans=' + value + '; path=/; domain=' + window.location.hostname;
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const desktop = document.getElementById('lang-switcher');
+            const mobile = document.getElementById('lang-switcher-mobile');
+            const current = getCurrentLang();
+            if (desktop) desktop.value = current;
+            if (mobile) mobile.value = current;
+            [desktop, mobile].forEach(sel => {
+                if (sel) {
+                    sel.addEventListener('change', () => {
+                        setLang(sel.value);
+                        location.reload();
+                    });
+                }
+            });
+        });
     </script>
     <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>

--- a/supports/support.html
+++ b/supports/support.html
@@ -52,7 +52,13 @@
         <nav class="hidden md:flex space-x-8 items-center">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <div id="google_translate_element" class="hidden md:block"></div>
+        <select id="lang-switcher" class="hidden md:block border border-gray-300 rounded-md text-sm px-2 py-1 ml-4">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element" class="hidden"></div>
         <!-- Mobile menu button (hidden on desktop) -->
                <button id="mobile-menu-button" class="md:hidden text-primary-dark hover:text-accent focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -64,7 +70,13 @@
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <div id="google_translate_element_mobile" class="mt-4"></div>
+        <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element_mobile" class="hidden"></div>
     </div>
 
     <!-- Main Content Container - Styled like a card -->
@@ -141,8 +153,34 @@
                 layout: google.translate.TranslateElement.InlineLayout.SIMPLE
             }, 'google_translate_element_mobile');
         }
+
+        function getCurrentLang() {
+            const match = document.cookie.match(/googtrans=\/auto\/([^;]+)/);
+            return match ? match[1] : 'zh-TW';
+        }
+
+        function setLang(lang) {
+            const value = '/auto/' + lang;
+            document.cookie = 'googtrans=' + value + '; path=/';
+            document.cookie = 'googtrans=' + value + '; path=/; domain=' + window.location.hostname;
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const desktop = document.getElementById('lang-switcher');
+            const mobile = document.getElementById('lang-switcher-mobile');
+            const current = getCurrentLang();
+            if (desktop) desktop.value = current;
+            if (mobile) mobile.value = current;
+            [desktop, mobile].forEach(sel => {
+                if (sel) {
+                    sel.addEventListener('change', () => {
+                        setLang(sel.value);
+                        location.reload();
+                    });
+                }
+            });
+        });
     </script>
     <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
-    <!-- Language Toggle Script removed -->
 </body>
 </html>

--- a/terms/terms.html
+++ b/terms/terms.html
@@ -45,7 +45,13 @@
         <nav class="hidden md:flex space-x-8 items-center">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <div id="google_translate_element" class="hidden md:block"></div>
+        <select id="lang-switcher" class="hidden md:block border border-gray-300 rounded-md text-sm px-2 py-1 ml-4">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element" class="hidden"></div>
         <!-- Mobile menu button (hidden on desktop) -->
           <button id="mobile-menu-button" class="md:hidden text-primary-dark hover:text-accent focus:outline-none">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -57,7 +63,13 @@
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <div id="google_translate_element_mobile" class="mt-4"></div>
+        <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">
+            <option value="zh-TW">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="ja">日本語</option>
+        </select>
+        <div id="google_translate_element_mobile" class="hidden"></div>
     </div>
 
     <!-- Main Content Container - Styled like a card -->
@@ -234,6 +246,33 @@
                 layout: google.translate.TranslateElement.InlineLayout.SIMPLE
             }, 'google_translate_element_mobile');
         }
+
+        function getCurrentLang() {
+            const match = document.cookie.match(/googtrans=\/auto\/([^;]+)/);
+            return match ? match[1] : 'zh-TW';
+        }
+
+        function setLang(lang) {
+            const value = '/auto/' + lang;
+            document.cookie = 'googtrans=' + value + '; path=/';
+            document.cookie = 'googtrans=' + value + '; path=/; domain=' + window.location.hostname;
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const desktop = document.getElementById('lang-switcher');
+            const mobile = document.getElementById('lang-switcher-mobile');
+            const current = getCurrentLang();
+            if (desktop) desktop.value = current;
+            if (mobile) mobile.value = current;
+            [desktop, mobile].forEach(sel => {
+                if (sel) {
+                    sel.addEventListener('change', () => {
+                        setLang(sel.value);
+                        location.reload();
+                    });
+                }
+            });
+        });
     </script>
     <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>


### PR DESCRIPTION
## Summary
- add custom language dropdowns to header and mobile menu
- hook dropdowns to Google Translate to switch between Traditional Chinese, English, Korean and Japanese

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881088999e8832bb041657a7cf8d8ad