### PR TITLE
Fix mobile menu spacing and transparency

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -36,7 +36,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section - Matching Homepage Style -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/70 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
          <a href="../index.html" class="flex items-center space-x-2">
             <img src="../assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-8 h-8 object-contain" />
             <div class="text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -59,7 +59,7 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4 fixed top-20 left-0 right-0 z-20">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
@@ -157,11 +157,24 @@
         </div>
    </footer>
     <script>
-        const menuBtn = document.getElementById('mobile-menu-button');
-        const mobileMenu = document.getElementById('mobile-menu');
+        const menuBtn = document.getElementById("mobile-menu-button");
+        const mobileMenu = document.getElementById("mobile-menu");
         if (menuBtn && mobileMenu) {
-            menuBtn.addEventListener('click', () => {
-                mobileMenu.classList.toggle('hidden');
+            menuBtn.addEventListener("click", () => {
+                if (mobileMenu.classList.contains("hidden")) {
+                    mobileMenu.classList.remove("hidden");
+                    requestAnimationFrame(() => {
+                        mobileMenu.classList.remove("-translate-y-4", "opacity-0");
+                        mobileMenu.classList.add("translate-y-0", "opacity-100");
+                    });
+                } else {
+                    mobileMenu.classList.add("-translate-y-4", "opacity-0");
+                    mobileMenu.classList.remove("translate-y-0", "opacity-100");
+                    mobileMenu.addEventListener("transitionend", function handler(){
+                        mobileMenu.classList.add("hidden");
+                        mobileMenu.removeEventListener("transitionend", handler);
+                    }, { once: true });
+                }
             });
         }
     </script>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/70 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
         <a href="index.html" class="flex items-center space-x-2">
             <img src="assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-10 h-10 object-contain" />
             <div class="text-xl md:text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -71,7 +71,7 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4 fixed top-20 left-0 right-0 z-20">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
         <nav class="flex flex-col space-y-4">
             <a id="nav-mobile-home" href="#" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
             <a id="nav-mobile-features" href="#features" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
@@ -378,15 +378,33 @@
         </div>
     </footer>
     <script>
-        const menuBtn = document.getElementById('mobile-menu-button');
-        const mobileMenu = document.getElementById('mobile-menu');
+        const menuBtn = document.getElementById("mobile-menu-button");
+        const mobileMenu = document.getElementById("mobile-menu");
         if (menuBtn && mobileMenu) {
-            menuBtn.addEventListener('click', () => {
-                mobileMenu.classList.toggle('hidden');
+            menuBtn.addEventListener("click", () => {
+                if (mobileMenu.classList.contains("hidden")) {
+                    mobileMenu.classList.remove("hidden");
+                    requestAnimationFrame(() => {
+                        mobileMenu.classList.remove("-translate-y-4", "opacity-0");
+                        mobileMenu.classList.add("translate-y-0", "opacity-100");
+                    });
+                } else {
+                    mobileMenu.classList.add("-translate-y-4", "opacity-0");
+                    mobileMenu.classList.remove("translate-y-0", "opacity-100");
+                    mobileMenu.addEventListener("transitionend", function handler(){
+                        mobileMenu.classList.add("hidden");
+                        mobileMenu.removeEventListener("transitionend", handler);
+                    }, { once: true });
+                }
             });
-            mobileMenu.querySelectorAll('a').forEach(link => {
-                link.addEventListener('click', () => {
-                    mobileMenu.classList.add('hidden');
+            mobileMenu.querySelectorAll("a").forEach(link => {
+                link.addEventListener("click", () => {
+                    mobileMenu.classList.add("-translate-y-4", "opacity-0");
+                    mobileMenu.classList.remove("translate-y-0", "opacity-100");
+                    mobileMenu.addEventListener("transitionend", function handler(){
+                        mobileMenu.classList.add("hidden");
+                        mobileMenu.removeEventListener("transitionend", handler);
+                    }, { once: true });
                 });
             });
         }

--- a/supports/support.html
+++ b/supports/support.html
@@ -43,7 +43,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section - Matching Homepage Style -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/70 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
          <a href="../index.html" class="flex items-center space-x-2">
             <img src="../assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-8 h-8 object-contain" />
             <div id="site-name" class="text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -66,7 +66,7 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4 fixed top-20 left-0 right-0 z-20">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
         <nav class="flex flex-col space-y-4">
             <a id="nav-mobile-home" href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
@@ -131,11 +131,24 @@
         </div>
     </footer>
     <script>
-        const menuBtn = document.getElementById('mobile-menu-button');
-        const mobileMenu = document.getElementById('mobile-menu');
+        const menuBtn = document.getElementById("mobile-menu-button");
+        const mobileMenu = document.getElementById("mobile-menu");
         if (menuBtn && mobileMenu) {
-            menuBtn.addEventListener('click', () => {
-                mobileMenu.classList.toggle('hidden');
+            menuBtn.addEventListener("click", () => {
+                if (mobileMenu.classList.contains("hidden")) {
+                    mobileMenu.classList.remove("hidden");
+                    requestAnimationFrame(() => {
+                        mobileMenu.classList.remove("-translate-y-4", "opacity-0");
+                        mobileMenu.classList.add("translate-y-0", "opacity-100");
+                    });
+                } else {
+                    mobileMenu.classList.add("-translate-y-4", "opacity-0");
+                    mobileMenu.classList.remove("translate-y-0", "opacity-100");
+                    mobileMenu.addEventListener("transitionend", function handler(){
+                        mobileMenu.classList.add("hidden");
+                        mobileMenu.removeEventListener("transitionend", handler);
+                    }, { once: true });
+                }
             });
         }
     </script>

--- a/terms/terms.html
+++ b/terms/terms.html
@@ -36,7 +36,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section - Matching Homepage Style -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/70 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
            <a href="../index.html" class="flex items-center space-x-2">
             <img src="../assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-8 h-8 object-contain" />
             <div class="text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -59,7 +59,7 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white shadow-md px-6 pb-4 fixed top-20 left-0 right-0 z-20">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
         <nav class="flex flex-col space-y-4">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
@@ -225,11 +225,24 @@
         </div>
     </footer>
     <script>
-        const menuBtn = document.getElementById('mobile-menu-button');
-        const mobileMenu = document.getElementById('mobile-menu');
+        const menuBtn = document.getElementById("mobile-menu-button");
+        const mobileMenu = document.getElementById("mobile-menu");
         if (menuBtn && mobileMenu) {
-            menuBtn.addEventListener('click', () => {
-                mobileMenu.classList.toggle('hidden');
+            menuBtn.addEventListener("click", () => {
+                if (mobileMenu.classList.contains("hidden")) {
+                    mobileMenu.classList.remove("hidden");
+                    requestAnimationFrame(() => {
+                        mobileMenu.classList.remove("-translate-y-4", "opacity-0");
+                        mobileMenu.classList.add("translate-y-0", "opacity-100");
+                    });
+                } else {
+                    mobileMenu.classList.add("-translate-y-4", "opacity-0");
+                    mobileMenu.classList.remove("translate-y-0", "opacity-100");
+                    mobileMenu.addEventListener("transitionend", function handler(){
+                        mobileMenu.classList.add("hidden");
+                        mobileMenu.removeEventListener("transitionend", handler);
+                    }, { once: true });
+                }
             });
         }
     </script>


### PR DESCRIPTION
## Summary
- fix header and mobile menu to use 70% transparent background
- remove gap below header on small screens
- animate mobile menu opening and closing

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884f9a87344832bb22b79f73635ed65