### PR TITLE
Adjust opacity and add separators

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -36,7 +36,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section - Matching Homepage Style -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white/90 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/95 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
          <a href="../index.html" class="flex items-center space-x-2">
             <img src="../assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-8 h-8 object-contain" />
             <div class="text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -59,8 +59,8 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
-        <nav class="flex flex-col space-y-4">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/95 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
+        <nav class="flex flex-col divide-y divide-gray-200">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
         <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white/90 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/95 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
         <a href="index.html" class="flex items-center space-x-2">
             <img src="assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-10 h-10 object-contain" />
             <div class="text-xl md:text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -71,8 +71,8 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
-        <nav class="flex flex-col space-y-4">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/95 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
+        <nav class="flex flex-col divide-y divide-gray-200">
             <a id="nav-mobile-home" href="#" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
             <a id="nav-mobile-features" href="#features" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
             <a id="nav-mobile-showcase" href="#showcase" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>

--- a/supports/support.html
+++ b/supports/support.html
@@ -43,7 +43,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section - Matching Homepage Style -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white/90 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/95 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
          <a href="../index.html" class="flex items-center space-x-2">
             <img src="../assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-8 h-8 object-contain" />
             <div id="site-name" class="text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -66,8 +66,8 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
-        <nav class="flex flex-col space-y-4">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/95 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
+        <nav class="flex flex-col divide-y divide-gray-200">
             <a id="nav-mobile-home" href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
         <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">

--- a/terms/terms.html
+++ b/terms/terms.html
@@ -36,7 +36,7 @@
 </head>
 <body class="antialiased pt-20">
     <!-- Header Section - Matching Homepage Style -->
-    <header class="fixed top-0 left-0 right-0 z-10 bg-white/90 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
+    <header class="fixed top-0 left-0 right-0 z-10 bg-white/95 shadow-sm py-4 px-6 md:px-12 flex justify-between items-center rounded-b-xl">
            <a href="../index.html" class="flex items-center space-x-2">
             <img src="../assets/start_tracking_meals_with_white_bg.png" alt="Logo" class="w-8 h-8 object-contain" />
             <div class="text-2xl font-bold text-[#2D2926]">記食開始</div>
@@ -59,8 +59,8 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white/70 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
-        <nav class="flex flex-col space-y-4">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/95 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
+        <nav class="flex flex-col divide-y divide-gray-200">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
         <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">


### PR DESCRIPTION
## Summary
- increase header and mobile menu opacity to 95%
- add divider lines between mobile menu items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885b54815b4832ba597c7cc5704e0a2