### PR TITLE
Adjust mobile menu spacing and hero text

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,12 +71,12 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="md:hidden hidden bg-white/95 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0">
+    <div id="mobile-menu" class="md:hidden hidden bg-white/95 shadow-md px-6 pb-4 fixed top-[4.5rem] left-0 right-0 z-20 transition-transform transition-opacity duration-300 transform -translate-y-4 opacity-0 rounded-b-xl">
         <nav class="flex flex-col divide-y divide-gray-200">
-            <a id="nav-mobile-home" href="#" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
-            <a id="nav-mobile-features" href="#features" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
-            <a id="nav-mobile-showcase" href="#showcase" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
-            <a id="nav-mobile-qanda" href="#qanda" class="text-xl py-3 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">Q&A</a>
+            <a id="nav-mobile-home" href="#" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
+            <a id="nav-mobile-features" href="#features" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
+            <a id="nav-mobile-showcase" href="#showcase" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
+            <a id="nav-mobile-qanda" href="#qanda" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">Q&A</a>
         </nav>
         <select id="lang-switcher-mobile" class="mt-4 bg-gray-50 rounded-lg shadow text-sm px-2 py-1 transition-colors duration-200 hover:bg-gray-100">
             <option value="zh-TW">繁體中文</option>
@@ -94,7 +94,7 @@
                 記食開始
             </h1>
             <h1 id="hero-title2" class="text-1xl md:text-2xl lg:text-3xl font-extrabold leading-tight mb-6">
-                讓你愛上 <span class="text-[#ECD676]">記錄飲食</span> 的App
+                讓你愛上 <span class="text-[#ECD676]"><span class="text-base md:text-2xl lg:text-3xl">記</span>錄飲<span class="text-base md:text-2xl lg:text-3xl">食</span></span> 的App
             </h1>
             <p id="hero-p1" class="text-lg md:text-xl mb-0 max-w-2xl mx-auto md:mx-0 opacity-70">
                 輕鬆管理飲食、追蹤每日熱量與營養，讓健康目標不再遙不可及！
@@ -442,7 +442,7 @@
                 'nav-mobile-showcase': '版本比較',
                 'nav-mobile-qanda': 'Q&A',
                 'hero-title1': '記食開始',
-                'hero-title2': '讓你愛上 <span class="text-[#ECD676] text-5xl">記</span><span class="text-[#2D2926]">錄飲</span><span class="text-[#ECD676] text-5xl">食</span> 的App',
+                'hero-title2': '讓你愛上 <span class="text-[#ECD676]"><span class="text-base md:text-2xl lg:text-3xl">記</span>錄飲<span class="text-base md:text-2xl lg:text-3xl">食</span></span> 的App',
                 'hero-p1': '輕鬆管理飲食、追蹤每日熱量與營養，讓健康目標不再遙不可及！',
                 'hero-p2': '使用AI與攝影技術，快速記下你每日所吃的一切，從健康分析到喝水提醒，打造你的飲食生活習慣！',
                 'features-title': '主要功能',


### PR DESCRIPTION
## Summary
- bump mobile menu padding and add bottom corner radius
- tweak mobile hero heading so "記" and "食" are smaller on phones

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885bd4dfa48832ba65d9f5e3db137ce