### PR TITLE
Update language switcher layout and Q&A text

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -45,7 +45,7 @@
         <nav class="hidden md:flex space-x-8">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <select id="lang-switcher" class="hidden md:block border border-gray-300 rounded-md text-sm px-2 py-1 ml-4">
+        <select id="lang-switcher" class="border border-gray-300 rounded-md text-sm px-2 py-1 ml-4 mr-2">
             <option value="zh-TW">繁體中文</option>
             <option value="en">English</option>
             <option value="ko">한국어</option>
@@ -63,12 +63,6 @@
         <nav class="flex flex-col divide-y divide-gray-200">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">
-            <option value="zh-TW">繁體中文</option>
-            <option value="en">English</option>
-            <option value="ko">한국어</option>
-            <option value="ja">日本語</option>
-        </select>
         <div id="google_translate_element_mobile" class="hidden"></div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -56,9 +56,9 @@
             <a id="nav-home" href="#" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
             <a id="nav-features" href="#features" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
             <a id="nav-showcase" href="#showcase" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
-            <a id="nav-qanda" href="#qanda" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">Q&A</a>
+            <a id="nav-qanda" href="#qanda" class="text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">常見問題</a>
         </nav>
-        <select id="lang-switcher" class="hidden md:block bg-gray-50 rounded-lg shadow text-sm px-2 py-1 ml-4 transition-colors duration-200 hover:bg-gray-100">
+        <select id="lang-switcher" class="bg-gray-50 rounded-lg shadow text-sm px-2 py-1 ml-4 mr-2 transition-colors duration-200 hover:bg-gray-100">
             <option value="zh-TW">繁體中文</option>
             <option value="en">English</option>
             <option value="ko">한국어</option>
@@ -76,14 +76,9 @@
             <a id="nav-mobile-home" href="#" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">首頁</a>
             <a id="nav-mobile-features" href="#features" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">功能說明</a>
             <a id="nav-mobile-showcase" href="#showcase" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">版本比較</a>
-            <a id="nav-mobile-qanda" href="#qanda" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">Q&A</a>
+            <a id="nav-mobile-qanda" href="#qanda" class="text-xl py-4 text-[#2D2926] hover:text-[#B8B0A6] font-medium transition-colors duration-200">常見問題</a>
         </nav>
-        <select id="lang-switcher-mobile" class="mt-4 bg-gray-50 rounded-lg shadow text-sm px-2 py-1 transition-colors duration-200 hover:bg-gray-100">
-            <option value="zh-TW">繁體中文</option>
-            <option value="en">English</option>
-            <option value="ko">한국어</option>
-            <option value="ja">日本語</option>
-        </select>
+        
     </div>
 
     <!-- Hero Section -->
@@ -436,11 +431,11 @@
                 'nav-home': '首頁',
                 'nav-features': '功能說明',
                 'nav-showcase': '版本比較',
-                'nav-qanda': 'Q&A',
+                'nav-qanda': '常見問題',
                 'nav-mobile-home': '首頁',
                 'nav-mobile-features': '功能說明',
                 'nav-mobile-showcase': '版本比較',
-                'nav-mobile-qanda': 'Q&A',
+                'nav-mobile-qanda': '常見問題',
                 'hero-title1': '記食開始',
                 'hero-title2': '讓你愛上 <span class="text-[#ECD676]"><span class="text-base md:text-2xl lg:text-3xl">記</span>錄飲<span class="text-base md:text-2xl lg:text-3xl">食</span></span> 的App',
                 'hero-p1': '輕鬆管理飲食、追蹤每日熱量與營養，讓健康目標不再遙不可及！',

--- a/supports/support.html
+++ b/supports/support.html
@@ -52,7 +52,7 @@
         <nav class="hidden md:flex space-x-8 items-center">
             <a id="nav-home" href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <select id="lang-switcher" class="hidden md:block border border-gray-300 rounded-md text-sm px-2 py-1 ml-4">
+        <select id="lang-switcher" class="border border-gray-300 rounded-md text-sm px-2 py-1 ml-4 mr-2">
             <option value="zh-TW">繁體中文</option>
             <option value="en">English</option>
             <option value="ko">한국어</option>
@@ -70,12 +70,6 @@
         <nav class="flex flex-col divide-y divide-gray-200">
             <a id="nav-mobile-home" href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">
-            <option value="zh-TW">繁體中文</option>
-            <option value="en">English</option>
-            <option value="ko">한국어</option>
-            <option value="ja">日本語</option>
-        </select>
     </div>
 
     <!-- Main Content Container - Styled like a card -->

--- a/terms/terms.html
+++ b/terms/terms.html
@@ -45,7 +45,7 @@
         <nav class="hidden md:flex space-x-8 items-center">
             <a href="../index.html" class="text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <select id="lang-switcher" class="hidden md:block border border-gray-300 rounded-md text-sm px-2 py-1 ml-4">
+        <select id="lang-switcher" class="border border-gray-300 rounded-md text-sm px-2 py-1 ml-4 mr-2">
             <option value="zh-TW">繁體中文</option>
             <option value="en">English</option>
             <option value="ko">한국어</option>
@@ -63,12 +63,6 @@
         <nav class="flex flex-col divide-y divide-gray-200">
             <a href="../index.html" class="text-xl py-3 text-primary-dark hover:text-accent font-medium transition-colors duration-200">首頁</a>
         </nav>
-        <select id="lang-switcher-mobile" class="mt-4 border border-gray-300 rounded-md text-sm px-2 py-1">
-            <option value="zh-TW">繁體中文</option>
-            <option value="en">English</option>
-            <option value="ko">한국어</option>
-            <option value="ja">日本語</option>
-        </select>
         <div id="google_translate_element_mobile" class="hidden"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- move language switcher outside the mobile menu so it sits next to the hamburger button
- rename Q&A navigation text to 常見問題

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885bef26f08832b88e6d0d74069bb17