### PR TITLE
Apply rounded corners to table and Q&A sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
     <section id="showcase" class="py-12 px-6 md:px-12 bg-gray-50 scroll-mt-20">
         <h2 id="showcase-title" class="text-2xl font-bold mb-10 text-center text-[#2D2926]">免費與Premium</h2>
         <div class="max-w-3xl mx-auto overflow-x-auto">
-            <table class="w-full table-auto text-center bg-white rounded-lg shadow-md">
+            <table class="w-full table-auto text-center bg-white rounded-lg overflow-hidden shadow-md">
                 <caption class="sr-only">功能比較表</caption>
                 <thead class="bg-gray-100 text-gray-700">
                     <tr>
@@ -311,7 +311,7 @@
     <section id="qanda" class="py-12 px-6 md:px-12 bg-white text-[#2D2926]">
         <h2 id="qa-title" class="text-2xl font-bold mb-10 text-center">常見問題</h2>
         <div id="qa-list" class="max-w-3xl mx-auto space-y-4">
-            <div class="border-b border-gray-200">
+            <div class="border border-gray-200 rounded-lg overflow-hidden">
                 <button type="button" data-answer="qa-a1" class="w-full flex justify-between items-center py-4 px-4 focus:outline-none bg-gray-100">
                     <span id="qa-q1" class="text-black text-base font-medium">記食開始App需要付費嗎？</span>
                     <span class="ml-2">+</span>
@@ -320,7 +320,7 @@
                     <p id="qa-a1-text">基本功能免費使用，但如果需要看到更視覺化的分析圖與自動辨識功能，可升級為 Premium 版本。</p>
                 </div>
             </div>
-            <div class="border-b border-gray-200">
+            <div class="border border-gray-200 rounded-lg overflow-hidden">
                 <button type="button" data-answer="qa-a2" class="w-full flex justify-between items-center py-4 px-4 focus:outline-none bg-gray-100">
                     <span id="qa-q2" class="text-black text-base font-medium">Premium 版有哪些額外功能？</span>
                     <span class="ml-2">+</span>
@@ -329,7 +329,7 @@
                     <p id="qa-a2-text">Premium 版本相關功能，可以參考上方的"功能說明"。</p>
                 </div>
             </div>
-            <div class="border-b border-gray-200">
+            <div class="border border-gray-200 rounded-lg overflow-hidden">
                 <button type="button" data-answer="qa-a3" class="w-full flex justify-between items-center py-4 px-4 focus:outline-none bg-gray-100">
                     <span id="qa-q3" class="text-black text-base font-medium">離線時可以使用嗎？</span>
                     <span class="ml-2">+</span>
@@ -338,7 +338,7 @@
                     <p id="qa-a3-text">大部分功能皆可離線使用，而個人記錄都會存在手機中，唯獨使用自動辨識功能需要開啟網路。</p>
                 </div>
             </div>
-            <div class="border-b border-gray-200">
+            <div class="border border-gray-200 rounded-lg overflow-hidden">
                 <button type="button" data-answer="qa-a4" class="w-full flex justify-between items-center py-4 px-4 focus:outline-none bg-gray-100">
                     <span id="qa-q4" class="text-black text-base font-medium">如何匯出我的記食資料？</span>
                     <span class="ml-2">+</span>
@@ -347,7 +347,7 @@
                     <p id="qa-a4-text">需要Premium 版本！在設定頁面的「資料匯出」即可分享所有紀錄。</p>
                 </div>
             </div>
-            <div class="border-b border-gray-200">
+            <div class="border border-gray-200 rounded-lg overflow-hidden">
                 <button type="button" data-answer="qa-a5" class="w-full flex justify-between items-center py-4 px-4 focus:outline-none bg-gray-100">
                     <span id="qa-q5" class="text-black text-base font-medium">目前支援哪些語言？</span>
                     <span class="ml-2">+</span>


### PR DESCRIPTION
## Summary
- make the comparison table corners rounded by clipping overflow
- round the edges of Q&A items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885c13ad19c832b864264bc19459074